### PR TITLE
traefik port host mode to pass client ip

### DIFF
--- a/docker/traefik-stack.yml
+++ b/docker/traefik-stack.yml
@@ -4,10 +4,15 @@ services:
   traefik:
     image: ghcr.io/justindoody/app-platform-traefik:${GITHUB_SHA}
     ports:
-      # The HTTP port
-      - "80:80"
-      # The HTTPS port
-      - "443:443"
+      # Using host mode to pass client IP's
+      # Listen on port 80, default for HTTP, necessary to redirect to HTTPS
+      - target: 80
+        published: 80
+        mode: host
+      # Listen on port 443, default for HTTPS
+      - target: 443
+        published: 443
+        mode: host
     volumes:
       # So that Traefik can listen to the Docker events
       - /var/run/docker.sock:/var/run/docker.sock

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,7 @@
+# Overview
+
+...
+
 ## Deploying
 
 ### Secrets & Config
@@ -17,3 +21,11 @@ docker stack deploy \
 -c docker-traefik.yml \
 traefik
 ```
+
+### Traefik Authentication
+
+Traefik is using basic auth to authenticate relying on the file provider which is reading from a docker secret `TRAEFIK_BASIC_AUTH_USERS`.
+
+User/pass combos generated via `echo $(htpasswd -nb user password)`.
+
+See [traefik docs for more](https://doc.traefik.io/traefik/middlewares/basicauth/#usersfile).


### PR DESCRIPTION
per https://dockerswarm.rocks/traefik/#getting-the-client-ip